### PR TITLE
Attach `shimport` for Firefox support

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
     </script>
     <link rel="stylesheet" href="/index.css" />
     <link rel="stylesheet" href="/library/prism.css" />
+    <script src="https://unpkg.com/shimport"></script>
     <script defer src="/library/prism.js"></script>
     <script defer src="/index.js" type="module"></script>
   </head>

--- a/index.js
+++ b/index.js
@@ -1,7 +1,20 @@
 import htm from 'https://unpkg.com/htm@2.1.1/dist/htm.mjs'
 import csz from 'https://unpkg.com/csz@0.1.2/index.js'
 
-import(location.hostname === 'localhost'
+// Call the native `import` if it exists.
+// This method isn't parsed initially & throws
+// "safely" in Firefox w/o killing the whole app.
+function shim(url) {
+  try {
+    return new Function(`return import('${url}')`).call();
+  } catch (tmp) {
+    // Relative ~> fully qualified URLs
+    (tmp = document.createElement('a')).href = url;
+    return __shimport__.load(tmp.href);
+  }
+}
+
+shim(location.hostname === 'localhost'
   ? 'https://unpkg.com/es-react@16.8.30/index.js'
   : 'https://unpkg.com/es-react-production@16.8.30/index.js').then(app)
 
@@ -14,8 +27,8 @@ function app({ React, ReactDOM }) {
     <div></div>
   `
   const Route = {
-    '/': React.lazy(() => import('./routes/home/index.js')),
-    '*': React.lazy(() => import('./routes/notfound/index.js')),
+    '/': React.lazy(() => shim('./routes/home/index.js')),
+    '*': React.lazy(() => shim('./routes/notfound/index.js')),
   }
 
   ReactDOM.render(


### PR DESCRIPTION
Uses [`shimport`](https://github.com/Rich-Harris/shimport) to safely swap between native `import()` and the fallback it provides. While it may be somewhat "overkill" for the rest of the project (aka, don't need module/ESM rewrite, etc), it allows the site to be functional across all browsers for the time being.

---

Closes #5 