### PR TITLE
Attach `dimport` for Firefox & Edge support

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,8 @@
     <link rel="stylesheet" href="/library/prism.css" />
     <link rel="stylesheet" href="/routes/home/index.css" />
     <script defer src="/library/prism.js"></script>
-    <script defer type="nomodule" src="https://unpkg.com/dimport/nomodule" data-main="/index.js"></script>
-    <script defer type="module" src="https://unpkg.com/dimport?module" data-main="/index.js"></script>
+    <script type="module" src="https://unpkg.com/dimport?module" data-main="/index.js"></script>
+    <script defer nomodule src="https://unpkg.com/dimport/nomodule" data-main="/index.js"></script>
   </head>
   <body></body>
 </html>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,8 @@
     <link rel="stylesheet" href="/library/prism.css" />
     <link rel="stylesheet" href="/routes/home/index.css" />
     <script defer src="/library/prism.js"></script>
-    <script defer src="/index.js" type="module"></script>
+    <script defer type="nomodule" src="https://unpkg.com/dimport/nomodule" data-main="/index.js"></script>
+    <script defer type="module" src="https://unpkg.com/dimport?module" data-main="/index.js"></script>
   </head>
   <body></body>
 </html>


### PR DESCRIPTION
Follow up to #8 and closes #5 

So, [`dimport`](https://github.com/lukeed/dimport) is the package that you coaxed me into making  😆 It offers multiple "modes" so that you can selectively choose how much you want it to do, whereas with the `shimport` PR, it was all-or-nothing.

Here, I attach `dimport`'s "nomodule" mode for browsers that don't support ESM at all. This version is like `shimport` in that it will incur (slightly) more overhead so that it can rewrite the files on the fly. Then, for browsers with module support, the default mode (aka, "module" mode) is loaded which tunnels everything thru a cascade of additional/temporary script tags.

The "module" mode is 675B. The "nomodule" mode is 918B.<br>
There's a third "legacy" mode (1.14kB) that extends support to IE, but I figured that you probably wouldn't want that here 😆 