### PR TITLE
Fixes test case name default bug

### DIFF
--- a/components/tests.js
+++ b/components/tests.js
@@ -33,7 +33,7 @@ export const TestControls = ({ id, test, state, dispatch }) => {
         disabled=${started}
         className=${style.nameInput}
         onInput=${e => dispatch(updateTestCaseName(id, e.target.value))}
-        value=${`${test.name || 'Test Case'}`}
+        value=${`${test.name}`}
       />
       <p>
         ${test.ops !== -2 &&

--- a/utils.js
+++ b/utils.js
@@ -132,7 +132,7 @@ export const copyTestCase = id => state => ({
 })
 
 export const addTestCase = state => ({
-  tests: [{ code: '', ops: -2 }, ...state.tests],
+  tests: [{ code: '', name: 'Test Case', ops: -2 }, ...state.tests],
 })
 
 export const setSearchTerm = searchTerm => state => ({


### PR DESCRIPTION
Fixes bug where when a test case title reaches 0 characters it is replaced by some default value.

![kapture_2020-04-01_at_16 05 03](https://user-images.githubusercontent.com/1457604/78154354-12c14980-7434-11ea-9f4b-2c97ad5ac7ef.gif)

