### PR TITLE
Fix safari issue on CDN, add pinned hooks url

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -1,5 +1,5 @@
 import * as preacts from 'https://cdn.pika.dev/pin/preact@v10.3.3-uhXRG2PBJBDIY1Ef8sXg/preact.js'
-import * as hooks from 'https://cdn.pika.dev/preact@v10.3.3/hooks'
+import * as hooks from 'https://cdn.pika.dev/pin/preact@v10.3.3-uhXRG2PBJBDIY1Ef8sXg/mode=exports/hooks'
 import css from 'https://cdn.pika.dev/pin/csz@v1.2.0-900XZmsdBeMLogkkQcD4/csz.js'
 import htm from 'https://cdn.pika.dev/pin/htm@v3.0.3-33cAE1PKrpVh0FdAUIDa/htm.js'
 import uid from 'https://cdn.pika.dev/pin/uid@v1.0.0-pGHaO3w0IERLifBCfHfR/uid.js'


### PR DESCRIPTION
Thanks for the ping! It looks like our new hooks support wasn't stripping sourcemap comments from the file, which caused Safari to show a console log about the missing sourcemap. Quick fix on our end! Also, tested locally in Safari/Firefox to confirm.

This should give you that speed benefit, and remove the risk of deps changing out from under you. 