### PR TITLE
Enable V1 perf.link's

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ import {
   latestLocalStorage,
   updateProgress,
   extractValidSuites,
+  decodeState,
 } from './utils.js'
 
 import Tests from './components/tests.js'
@@ -39,7 +40,7 @@ const defaults = {
 const init = location.hash
   ? {
       ...defaults,
-      ...JSON.parse(atob(decodeURIComponent(location.hash.slice(1)))),
+      ...decodeState(location.hash.slice(1)),
     }
   : defaults
 

--- a/utils.js
+++ b/utils.js
@@ -175,3 +175,33 @@ export const copyHashURL = (state) => {
   var result = document.execCommand('copy')
   document.body.removeChild(input)
 }
+
+export const decodeState = (encodedState) => {
+  try {
+    // V2
+    return JSON.parse(atob(decodeURIComponent(encodedState)))
+  } catch (e) {
+    console.log(e)
+  }
+
+  try {
+    // V1
+    return {
+      title: '',
+      before: atob(location.hash.slice(1).split('/')[0]),
+      tests: JSON.parse(atob(location.hash.slice(1).split('/')[1])).map(
+        ({ code }, testIndex) => {
+          return {
+            name: `Test ${testIndex + 1}`,
+            code,
+            ops: 0,
+          }
+        }
+      ),
+    }
+  } catch (e) {
+    console.log(e)
+  }
+
+  return {}
+}


### PR DESCRIPTION
This PR enables V1 links to work on the V2 perf.link site. Helpful for anyone who has any V1 links lying around. 

When the perf.link page is initialised it will attempt to decode the location hash using V2 schema, if that fails then it will attempt to decode using the V1 schema, if that fails then the default state will be used. If the URL contains a V1 hash then it will be updated in place to the V2 schema on page load.  

Here's some V1 links you can test when running this branch locally on 8080:

[.find](http://localhost:8080/#Y29uc3QgZGF0YSA9IFsuLi5BcnJheSgxMDAwMCkua2V5cygpXQ==/W3siY29kZSI6IiIsImVycm9yIjpmYWxzZSwibWVkaWFuIjowfSx7ImNvZGUiOiJkYXRhLmZpbmQoeCA9PiB4ID09IDUwMDApIiwiZXJyb3IiOmZhbHNlLCJtZWRpYW4iOjAuMDYwMDAwMDA1NzYwMjMwMTI0fSx7ImNvZGUiOiJkYXRhLmZpbmQoeCA9PiB4ID09IDEwMDAwKSIsImVycm9yIjpmYWxzZSwibWVkaWFuIjowLjExOTk5OTk5Njk2ODU0NTAyfV0=)
[.forEach vs. for](http://localhost:8080/#Y29uc3QgZGF0YSA9IFsuLi5BcnJheSgxMDAwMCkua2V5cygpXQ==/W3siY29kZSI6ImRhdGEuZm9yRWFjaCgoZGF0dW0pPT57XG5cbn0pIiwiZXJyb3IiOmZhbHNlLCJtZWRpYW4iOjAuMTMwMDAwMDAwMzUzOTAyNTh9LHsiY29kZSI6ImZvciAoY29uc3QgZGF0dW0gb2YgZGF0YSl7XG5cbn0iLCJlcnJvciI6ZmFsc2UsIm1lZGlhbiI6MC4wMDUwMDAwMDE2OTI2Nzg3Nzl9XQ==)

Happy to make any changes. 

