### PR TITLE
Support non-ascii Unicode characters (#36, #21)

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ const app = () => {
 
   useEffect(() => {
     const x = JSON.stringify({ id, title, before, tests, updated: new Date() })
-    history.replaceState(null, null, `#${encodeURIComponent(btoa(x))}`)
+    history.replaceState(null, null, `#${btoa(encodeURIComponent(x))}`)
     if (Object.fromEntries(suites)[id]) {
       localStorage.setItem(id, x)
       dispatch(latestLocalStorage)

--- a/utils.js
+++ b/utils.js
@@ -167,7 +167,7 @@ export const getColorForPercent = (value) =>
 
 export const copyHashURL = (state) => {
   const x = JSON.stringify(state)
-  const link = `${location.origin}#${encodeURIComponent(btoa(x))}`
+  const link = `${location.origin}#${btoa(encodeURIComponent(x))}`
   var input = document.createElement('input')
   input.setAttribute('value', link)
   document.body.appendChild(input)
@@ -179,7 +179,7 @@ export const copyHashURL = (state) => {
 export const decodeState = (encodedState) => {
   try {
     // V2
-    return JSON.parse(atob(decodeURIComponent(encodedState)))
+    return JSON.parse(decodeURIComponent(atob(encodedState)))
   } catch (e) {
     console.log(e)
   }


### PR DESCRIPTION
Fixes: #36 and #21 

Fixes "reversed" process for encode/decoding.
This should not affect any previously saved links (due to them failing if there was a Unicode character).